### PR TITLE
08_22_f05

### DIFF
--- a/rust-cli/src/main.rs
+++ b/rust-cli/src/main.rs
@@ -36,6 +36,12 @@ enum Commands {
         /// can I put something here?
         something: String,
     },
+    /// Gives you an animal based on vibes
+    Animal {
+        #[arg(short, long)]
+        /// How you vibin?
+        vibe_num: i32,
+    }
 }
 
 fn main() {
@@ -71,6 +77,17 @@ fn main() {
                 println!("Shhhh! I am speaking! I want to say: {}!", something);
             } else {
                 println!("Fine I won't say anything then, rat!");
+            }
+        }
+        Some(Commands::Animal {vibe_num}) => {
+            if *vibe_num == 22 {
+                println!("VIBES ARE IMMAACULATE!! You are a chubby SEAL!!");
+            } else if *vibe_num % 3 == 0 {
+                println!("Vibes are off man, A definite RAT number");
+            } else if *vibe_num %2 == 0 {
+                println!("The vibes are on! You are a SEAL!");
+            } else {
+                println!("Gross you pleb, pick a different number!");
             }
         }
         None => {}

--- a/rust-cli/src/main.rs
+++ b/rust-cli/src/main.rs
@@ -5,14 +5,14 @@ use clap::{Parser, Subcommand};
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Cli {
-    //optional name to operate on 
+    /// what's your name? .... TONY
     name: Option<String>,
 
-    //sets a custom config file
+    /// Stop FILE time
     #[arg(short, long, value_name = "FILE")]
     config: Option<PathBuf>,
 
-    //turn on debugging 
+    /// DEBUG more like LE BUG, hon hon hon french buggete
     #[arg(short, long, action = clap::ArgAction::Count)]
     debug: u8,
 
@@ -23,10 +23,18 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     //does test things
-    //
+    /// Tests some stuff
     Test {
         #[arg(short, long)]
         list: bool,
+    },
+    
+    /// Shall I say something?
+    Speak {
+        #[arg(short, long)]
+        list: bool,
+        /// can I put something here?
+        something: String,
     },
 }
 
@@ -56,6 +64,13 @@ fn main() {
                 println!("Printin some testing lists....");
             } else {
                 println!("Not printin testing lists....");
+            }
+        }
+        Some(Commands::Speak {list, something}) => {
+            if * list {
+                println!("Shhhh! I am speaking! I want to say: {}!", something);
+            } else {
+                println!("Fine I won't say anything then, rat!");
             }
         }
         None => {}


### PR DESCRIPTION
## August 22nd, feature 05

Added two new sub commands, trying to figure out how sub commands work

Running: `rust-cli --help` will present you with menu:

```
Usage: rust-cli [OPTIONS] [NAME] [COMMAND]

Commands:
  test    Tests some stuff
  speak   Shall I say something?
  animal  Gives you an animal based on vibes
  help    Print this message or the help of the given subcommand(s)

Arguments
  [NAME]  what's your name? .... TONY

Options:
  -c, --config <FILE>  Stop FILE time
  -d, --debug...       DEBUG more like LE BUG, hon hon hon french buggete
  -h, --help           Print help
  -V, --version        Print version
```
Sub Commands added are animal and speak

Each also have their own options and arguments
`rust-cli animal --help`
```
Gives you an animal based on vibes

Usage: rust-cli animal --vibe-num <VIBE_NUM>

Options:
  -v, --vibe-num <VIBE_NUM>  How you vibin?
  -h, --help                 Print help
```

`rust-cli speak --help`
```
Shall I say something?

Usage: rust-cli speak [OPTIONS] <SOMETHING>

Arguments:
  <SOMETHING>  can I put something here?

Options:
  -l, --list  
  -h, --help  Print help
```

Adding sub commands (for now) seem to be straight forward: 
There's just an ENUM of sub commands with a derive attached like: 
```rust
#[derive(Subcommand)]
enum Commands {
    //does test things
    /// Tests some stuff
    Test {
        #[arg(short, long)]
        list: bool,
    },
    
    /// Shall I say something?
    Speak {
        #[arg(short, long)]
        list: bool,
        /// can I put something here?
        something: String,
    },
    /// Gives you an animal based on vibes
    Animal {
        #[arg(short, long)]
        /// How you vibin?
        vibe_num: i32,
    }
}

```

Haven't tried yet but you can probably call a function based on sub command input, which can let you do a whole bunch of stuff! Supah Savy Stuff!